### PR TITLE
feat(common): add support for "enableIBRRanking" query param

### DIFF
--- a/packages/common/params-specs/data.yml
+++ b/packages/common/params-specs/data.yml
@@ -980,6 +980,15 @@ enableExperimentalBlendPersonalization:
     - false
   default: true
 
+enableIBRRanking:
+  scope:
+    - search
+  value_type: boolean
+  values:
+    - true
+    - false
+  default: true
+
 experimentalDecompoundQuery:
   scope:
       - search


### PR DESCRIPTION
Add the `enableIBRRanking` allowing us to quickly add that as a query param.

TODO:
- [x] Re-index the query params in algolia