### PR TITLE
feat(metaparams): make pinned object pos start at 1

### DIFF
--- a/packages/common/components/explorer/synonyms-rules/PromotedHit.vue
+++ b/packages/common/components/explorer/synonyms-rules/PromotedHit.vue
@@ -16,7 +16,7 @@
                     <span v-if="position !== undefined">
                         at pos
                         <span class="text-cosmos-black-opacity-70">
-                            {{position}}
+                            {{position + 1}}
                         </span>
                     </span>
                 </div>

--- a/packages/common/components/explorer/synonyms-rules/RuleEdit.vue
+++ b/packages/common/components/explorer/synonyms-rules/RuleEdit.vue
@@ -207,9 +207,10 @@
                                     position
                                     <input
                                         type="number"
-                                        min="0"
+                                        min="1"
                                         max="1000"
-                                        v-model.number="newRule.promote[i].position"
+                                        :value="newRule.promote[i].position + 1"
+                                        @change="newRule.promote[i].position = parseInt($event.target.value) - 1"
                                         class="input-custom inline w-48"
                                     />
                                 </div>


### PR DESCRIPTION
This solves the discrepancy in positions between what we display at the top and the actual position displayed in the list.

Issue first mentioned here: https://algolia.slack.com/archives/CKCELM9HB/p1590669433050600