### PR TITLE
fix(css): monospace fonts in code

### DIFF
--- a/packages/css/styles.scss
+++ b/packages/css/styles.scss
@@ -118,7 +118,6 @@ input, input:focus, button, button:focus {
 
 pre {
   margin: 0;
-  font-family: Times, sans-serif;
   white-space: pre-wrap;
   word-wrap: break-word;
 }


### PR DESCRIPTION
before|after
---|---
<img width="326" alt="Screenshot 2020-06-05 at 15 58 19" src="https://user-images.githubusercontent.com/6270048/83884881-d832a080-a745-11ea-9745-c6cc769bfa2b.png"> | <img width="464" alt="Screenshot 2020-06-05 at 15 58 13" src="https://user-images.githubusercontent.com/6270048/83884885-d9fc6400-a745-11ea-848a-80bea656e78d.png">
