### PR TITLE
feat: add IBRPromoteExclusionFilter search query param

### DIFF
--- a/packages/common/params-specs/data.yml
+++ b/packages/common/params-specs/data.yml
@@ -989,6 +989,12 @@ enableIBRRanking:
     - false
   default: true
 
+IBRPromoteExclusionFilter:
+  scope:
+    - search
+  value_type: string
+  default: ""
+
 experimentalDecompoundQuery:
   scope:
       - search


### PR DESCRIPTION
This parameter allows to avoid promoting items that match the filter.
Filtering can only be done on attributes that are facetted.

The naming of this param will likely change in the future, but given its hard to remember having it autocompleted will be super useful.

Example usage: https://tools.algolia.com/metaparams?code=5f3f7548b8d73