### PR TITLE
feat: rename re-ranking params

### DIFF
--- a/packages/common/params-specs/data.yml
+++ b/packages/common/params-specs/data.yml
@@ -980,8 +980,9 @@ enableExperimentalBlendPersonalization:
     - false
   default: true
 
-enableIBRRanking:
+enableReRanking:
   scope:
+    - settings
     - search
   value_type: boolean
   values:
@@ -989,8 +990,9 @@ enableIBRRanking:
     - false
   default: true
 
-IBRPromoteExclusionFilter:
+reRankingApplyFilter:
   scope:
+    - settings
     - search
   value_type: string
   default: ""


### PR DESCRIPTION
Re-ranking parameters are now in their final name, so let's update them.
They can now also be set directly in the index settings so we add that as well.