### PR TITLE
fix(relevantSorting): typo in attributes

### DIFF
--- a/packages/common/components/explorer/results/Weights.vue
+++ b/packages/common/components/explorer/results/Weights.vue
@@ -7,8 +7,8 @@
                     <td><input type="number" v-model="weights.typo" min="0" max="10" class="input-custom ml-8"></td>
                 </tr>
                 <tr>
-                    <td>attributes</td>
-                    <td><input type="number" v-model="weights.attributes" min="0" max="10" class="input-custom ml-8"></td>
+                    <td>attribute</td>
+                    <td><input type="number" v-model="weights.attribute" min="0" max="10" class="input-custom ml-8"></td>
                 </tr>
                 <tr>
                     <td>words</td>
@@ -45,7 +45,7 @@
             return {
                 weights: {
                     typo: 10,
-                    attributes: 10,
+                    attribute: 10,
                     words: 9,
                     proximity: 2,
                     exact: 2,


### PR DESCRIPTION
Here we are using `attribute` as a map key.

https://github.com/algolia/tools/blob/295ac0ba9c0ee1495c48e1cb778e5a3c421fb748/packages/common/components/explorer/results/similarity.js#L3-L12

But the key was set as `attributes` in `Weights.vue`.. making attributes to be ignored in the similarity computation