### PR TITLE
fix(similarity): computation for attributes

### DIFF
--- a/packages/common/components/explorer/results/PerformSearch.vue
+++ b/packages/common/components/explorer/results/PerformSearch.vue
@@ -40,7 +40,7 @@
                 requestNumberReceived: 0,
                 requestNumberAnalysis: 0,
                 requestNumberAnalysisReceived: 0,
-                weights: {typo: 10, attributes: 10, words: 9, proximity: 2, exact: 2, filters: 1, geo: 1},
+                weights: {typo: 10, attribute: 10, words: 9, proximity: 2, exact: 2, filters: 1, geo: 1},
             }
         },
         created: async function () {

--- a/packages/common/components/explorer/results/similarity.js
+++ b/packages/common/components/explorer/results/similarity.js
@@ -3,7 +3,10 @@ import {getCriterionValue} from "../../../utils/rankingInfo";
 function buildRankingVector(item, weights) {
     let ret = [];
     ["typo", "geo", "words", "filters", "proximity", "attribute", "exact"].forEach((criterionName) => {
-        const val = getCriterionValue(item, criterionName);
+
+        // for attributes we need the original value from the engine
+        const val = criterionName == "attribute" ? item._rankingInfo.firstMatchedWord :  getCriterionValue(item, criterionName);
+
         if (Number.isInteger(val)) {
             // adding weight to the criteria to have a weighted cosine similarity
             ret.push((weights[criterionName] || 0) * val)


### PR DESCRIPTION
Two fixes here:

- One typo when passing `attributes` in PerformSearch, attributes is singular
- To compute the similarity we need the original value from the engine and not the one divided by 1000

Before:
![Screenshot 2020-12-03 at 19 25 17](https://user-images.githubusercontent.com/22633119/101072525-7640df80-359e-11eb-951f-fc6b1227cacc.png)

After:
![Screenshot 2020-12-03 at 19 24 20](https://user-images.githubusercontent.com/22633119/101072514-7214c200-359e-11eb-9f03-7a914d6c8c03.png)


