### PR TITLE
fix(smartSorting): use matched attribute position for cosine sim

### DIFF
--- a/packages/common/components/explorer/results/similarity.js
+++ b/packages/common/components/explorer/results/similarity.js
@@ -5,7 +5,7 @@ function buildRankingVector(item, weights) {
     ["typo", "geo", "words", "filters", "proximity", "attribute", "exact"].forEach((criterionName) => {
 
         // for attributes we need the original value from the engine
-        const val = criterionName == "attribute" ? item._rankingInfo.firstMatchedWord :  getCriterionValue(item, criterionName);
+        const val = criterionName == "attribute" ? Math.floor(item._rankingInfo.firstMatchedWord / 1000.) :  getCriterionValue(item, criterionName);
 
         if (Number.isInteger(val)) {
             // adding weight to the criteria to have a weighted cosine similarity


### PR DESCRIPTION
The cosine similarity algorithm of the engine now uses the matched `attributes` position for its computation.
Let's reflect it in metaparams for a better debugging experience. 