### PR TITLE
fix(build): use legacy ssl provider in vue-cli-service in node 18+

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "apps",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "common": "^0.0.0",
-    "vue": "^2.6",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "apps",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
+    },
+    "dependencies": {
+        "common": "^0.0.0",
+        "vue": "^2.6",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }

--- a/packages/index-analyzer/package.json
+++ b/packages/index-analyzer/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "index-analyzer",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "common": "^0.0.0",
-    "vue": "^2.6",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "index-analyzer",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
+    },
+    "dependencies": {
+        "common": "^0.0.0",
+        "vue": "^2.6",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }

--- a/packages/index-differ/package.json
+++ b/packages/index-differ/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "index-differ",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "algolia-filters-js-syntax-validator": "^1.0.2",
-    "algoliasearch": "^4.1.0",
-    "chart.js": "^2.8.0",
-    "common": "^0.0.0",
-    "decode-uri-component": "^0.2.0",
-    "dedent": "^0.7.0",
-    "diff": "^4.0.1",
-    "diff2html": "^2.11.3",
-    "js-yaml-loader": "^1.0.1",
-    "moment": "^2.24.0",
-    "prismjs": "^1.15.0",
-    "serve-static": "^1.13.2",
-    "vue": "^2.6",
-    "vue-chartjs": "^3.4.2",
-    "vue-input-autowidth": "^1.0.3",
-    "vue2-brace-editor": "^2.0.2",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "index-differ",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
+    },
+    "dependencies": {
+        "algolia-filters-js-syntax-validator": "^1.0.2",
+        "algoliasearch": "^4.1.0",
+        "chart.js": "^2.8.0",
+        "common": "^0.0.0",
+        "decode-uri-component": "^0.2.0",
+        "dedent": "^0.7.0",
+        "diff": "^4.0.1",
+        "diff2html": "^2.11.3",
+        "js-yaml-loader": "^1.0.1",
+        "moment": "^2.24.0",
+        "prismjs": "^1.15.0",
+        "serve-static": "^1.13.2",
+        "vue": "^2.6",
+        "vue-chartjs": "^3.4.2",
+        "vue-input-autowidth": "^1.0.3",
+        "vue2-brace-editor": "^2.0.2",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }

--- a/packages/index-manager/package.json
+++ b/packages/index-manager/package.json
@@ -1,38 +1,38 @@
 {
-  "name": "index_manager",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint",
-    "css": "tailwind build src/assets/css/main.scss -c tailwind.js -o src/assets/css/all.css"
-  },
-  "dependencies": {
-    "algolia-filters-js-syntax-validator": "^1.0.2",
-    "algoliasearch": "^4.1.0",
-    "chart.js": "^2.8.0",
-    "common": "^0.0.0",
-    "dedent": "^0.7.0",
-    "js-yaml-loader": "^1.0.1",
-    "moment": "^2.24.0",
-    "prismjs": "^1.15.0",
-    "serve-static": "^1.13.2",
-    "vue": "^2.6",
-    "vue-chartjs": "^3.4.2",
-    "vue-input-autowidth": "^1.0.3",
-    "vue2-brace-editor": "^2.0.2",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "index_manager",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint",
+        "css": "tailwind build src/assets/css/main.scss -c tailwind.js -o src/assets/css/all.css"
+    },
+    "dependencies": {
+        "algolia-filters-js-syntax-validator": "^1.0.2",
+        "algoliasearch": "^4.1.0",
+        "chart.js": "^2.8.0",
+        "common": "^0.0.0",
+        "dedent": "^0.7.0",
+        "js-yaml-loader": "^1.0.1",
+        "moment": "^2.24.0",
+        "prismjs": "^1.15.0",
+        "serve-static": "^1.13.2",
+        "vue": "^2.6",
+        "vue-chartjs": "^3.4.2",
+        "vue-input-autowidth": "^1.0.3",
+        "vue2-brace-editor": "^2.0.2",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }

--- a/packages/insights-ui/package.json
+++ b/packages/insights-ui/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "insights-ui",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "common": "^0.0.0",
-    "search-insights": "^1.6.2",
-    "vue": "^2.6",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "insights-ui",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
+    },
+    "dependencies": {
+        "common": "^0.0.0",
+        "search-insights": "^1.6.2",
+        "vue": "^2.6",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }

--- a/packages/logs/package.json
+++ b/packages/logs/package.json
@@ -1,38 +1,38 @@
 {
-  "name": "api_logs",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "algolia-filters-js-syntax-validator": "^1.0.2",
-    "algoliasearch": "^4.1.0",
-    "chart.js": "^2.8.0",
-    "common": "^0.0.0",
-    "decode-uri-component": "^0.2.0",
-    "dedent": "^0.7.0",
-    "js-yaml-loader": "^1.0.1",
-    "moment": "^2.24.0",
-    "prismjs": "^1.15.0",
-    "serve-static": "^1.13.2",
-    "vue": "^2.6",
-    "vue-chartjs": "^3.4.2",
-    "vue-input-autowidth": "^1.0.3",
-    "vue2-brace-editor": "^2.0.2",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "api_logs",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
+    },
+    "dependencies": {
+        "algolia-filters-js-syntax-validator": "^1.0.2",
+        "algoliasearch": "^4.1.0",
+        "chart.js": "^2.8.0",
+        "common": "^0.0.0",
+        "decode-uri-component": "^0.2.0",
+        "dedent": "^0.7.0",
+        "js-yaml-loader": "^1.0.1",
+        "moment": "^2.24.0",
+        "prismjs": "^1.15.0",
+        "serve-static": "^1.13.2",
+        "vue": "^2.6",
+        "vue-chartjs": "^3.4.2",
+        "vue-input-autowidth": "^1.0.3",
+        "vue2-brace-editor": "^2.0.2",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }

--- a/packages/logs/src/api-logs/findOperation.js
+++ b/packages/logs/src/api-logs/findOperation.js
@@ -72,7 +72,7 @@ const operations = [
 
     new Operation('DELETE', '/1/indexes/:idx/synonyms/:id', (logItem, idx, id) => `<code>Delete synonym</code> ${escapeHtml(id)} for index <code>${escapeHtml(idx)}</code>`),
     new Operation('POST', '/1/indexes/:idx/synonyms/clear', (logItem, idx) => `<code>Clear synonyms</code> for index <code>${escapeHtml(idx)}</code>`),
-    new Operation('POST', '/1/indexes/:idx/synonyms/batch', (logItem, idx) => `<code>Batch ${escapeHtml(logItem).nb_operations} synonyms</code> for index <code>${escapeHtml(idx)}</code>`),
+    new Operation('POST', '/1/indexes/:idx/synonyms/batch', (logItem, idx) => `<code>Batch ${escapeHtml(logItem.nb_operations)} synonyms</code> for index <code>${escapeHtml(idx)}</code>`),
     new Operation('POST', '/1/indexes/:idx/synonyms/search', (logItem, idx) => `Search synonyms in index <code>${escapeHtml(idx)}</code>`),
     new Operation('GET', '/1/indexes/:idx/synonyms/:id', (logItem, idx, id) => `<code>Get synonym</code> ${escapeHtml(id)} for index <code>${escapeHtml(idx)}</code>`),
     new Operation('PUT', '/1/indexes/:idx/synonyms/:id', (logItem, idx, id) => `<code>Add/Update synonym</code> ${escapeHtml(id)} for index <code>${escapeHtml(idx)}</code>`),

--- a/packages/metaparams/package.json
+++ b/packages/metaparams/package.json
@@ -3,10 +3,10 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "serve": "vue-cli-service serve",
-        "build": "vue-cli-service build",
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
         "start": "node server.js",
-        "lint": "vue-cli-service lint"
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
     },
     "dependencies": {
         "algolia-filters-js-syntax-validator": "^1.0.2",

--- a/packages/relevance-testing/package.json
+++ b/packages/relevance-testing/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "relevance-testing",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "algolia-filters-js-syntax-validator": "^1.0.2",
-    "algoliasearch": "^4.1.0",
-    "chart.js": "^2.8.0",
-    "common": "^0.0.0",
-    "create-hmac": "^1.1.7",
-    "d3-dsv": "^1.1.1",
-    "decode-uri-component": "^0.2.0",
-    "dedent": "^0.7.0",
-    "js-yaml-loader": "^1.0.1",
-    "moment": "^2.24.0",
-    "prismjs": "^1.15.0",
-    "serve-static": "^1.13.2",
-    "vue": "^2.6",
-    "vue-chartjs": "^3.4.2",
-    "vue-input-autowidth": "^1.0.3",
-    "vue-router": "^3.1.2",
-    "vue2-brace-editor": "^2.0.2",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "relevance-testing",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
+    },
+    "dependencies": {
+        "algolia-filters-js-syntax-validator": "^1.0.2",
+        "algoliasearch": "^4.1.0",
+        "chart.js": "^2.8.0",
+        "common": "^0.0.0",
+        "create-hmac": "^1.1.7",
+        "d3-dsv": "^1.1.1",
+        "decode-uri-component": "^0.2.0",
+        "dedent": "^0.7.0",
+        "js-yaml-loader": "^1.0.1",
+        "moment": "^2.24.0",
+        "prismjs": "^1.15.0",
+        "serve-static": "^1.13.2",
+        "vue": "^2.6",
+        "vue-chartjs": "^3.4.2",
+        "vue-input-autowidth": "^1.0.3",
+        "vue-router": "^3.1.2",
+        "vue2-brace-editor": "^2.0.2",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,31 +1,31 @@
 {
-  "name": "transform",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "start": "node server.js",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "common": "^0.0.0",
-    "monaco-editor": "^0.20.0",
-    "monaco-editor-webpack-plugin": "^1.9.0",
-    "oboe": "^2.1.5",
-    "papaparse": "^5.1.1",
-    "sax": "^1.2.4",
-    "vue": "^2.6",
-    "vuex": "^3.1.0"
-  },
-  "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.3.0",
-    "@vue/cli-plugin-eslint": "^3.3.0",
-    "@vue/cli-service": "^3.3.0"
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+    "name": "transform",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service --openssl-legacy-provider serve",
+        "build": "vue-cli-service --openssl-legacy-provider build",
+        "start": "node server.js",
+        "lint": "vue-cli-service --openssl-legacy-provider lint"
+    },
+    "dependencies": {
+        "common": "^0.0.0",
+        "monaco-editor": "^0.20.0",
+        "monaco-editor-webpack-plugin": "^1.9.0",
+        "oboe": "^2.1.5",
+        "papaparse": "^5.1.1",
+        "sax": "^1.2.4",
+        "vue": "^2.6",
+        "vuex": "^3.1.0"
+    },
+    "devDependencies": {
+        "@vue/cli-plugin-babel": "^3.3.0",
+        "@vue/cli-plugin-eslint": "^3.3.0",
+        "@vue/cli-service": "^3.3.0"
+    },
+    "browserslist": [
+        "> 1%",
+        "last 2 versions",
+        "not ie <= 8"
+    ]
 }


### PR DESCRIPTION
**What**

This PR adds a flag to all calls to `vue-cli-service` to supposedly fix a build issue that happens starting node 17+.
This fix is based off of: https://www.newline.co/@kchan/how-to-fix-the-error-errorerror0308010cdigital-envelope-routinesunsupported--0f8d3f17

**Note**
This also fixes a minor parenthesis issue on a log line generation.