### PR TITLE
feat(apps): Rework apps panel to provide recommendations on API Keys

### DIFF
--- a/packages/common/components/configuration/AppManagement.vue
+++ b/packages/common/components/configuration/AppManagement.vue
@@ -19,7 +19,7 @@
           </p>
           <p>
             <strong>
-              Always assess if the key you are using is using the least amount of privileges necessary for your needs:
+              Always assess if the key you are using has the least amount of privileges necessary for your needs:
             </strong>
           </p>
           <details

--- a/packages/common/components/configuration/AppManagement.vue
+++ b/packages/common/components/configuration/AppManagement.vue
@@ -1,72 +1,233 @@
 <template>
-    <div v-if="$store.state.panels.manageAppsPanel || Object.keys($store.state.apps).length <= 0" class="flex">
-        <div class="rounded bg-white m-16 mr-64 border border-solid border-proton-grey-opacity-60">
-            <div class="text-telluric-blue text-xs uppercase tracking-wide flex items-center border-b border-t-0 border-proton-grey p-8 bg-proton-grey-opacity-80">
-                <div>Manage AppIDs</div>
-                <close-icon
-                    class="cursor-pointer ml-auto w-12 h-12"
-                    @click="$store.commit('panels/setManageAppsPanel', false)"
-                />
+  <div
+    v-if="$store.state.panels.manageAppsPanel || Object.keys($store.state.apps).length <= 0"
+    class="flex"
+  >
+    <div class="rounded bg-white m-16 mr-64 border border-solid border-proton-grey-opacity-60">
+      <div class="text-telluric-blue text-xs uppercase tracking-wide flex items-center border-b border-t-0 border-proton-grey p-8 bg-proton-grey-opacity-80">
+        <div>Manage AppIDs</div>
+        <close-icon
+          class="cursor-pointer ml-auto w-12 h-12"
+          @click="$store.commit('panels/setManageAppsPanel', false)"
+        />
+      </div>
+      <div>
+        <div class="text-nova-grey bg-moon-grey-opacity-50 border border-proton-grey-opacity-20 m-8 p-8">
+          <p>
+            To function this app requires Algolia credentials. For most usage, a read-only API Key is sufficient.
+            If you need to modify the data, you will need a write API Key.
+          </p>
+          <p>
+            <strong>
+              Always assess if the key you are using is using the least amount of privileges necessary for your needs:
+            </strong>
+          </p>
+          <details
+            open
+            class="mt-8"
+          >
+            <summary>General</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">listIndices</code> (optional) You can search for indices in the index input instead of just typing your index name.
+                </li>
+              </ul>
             </div>
-            <div>
-                <div class="text-nova-grey bg-moon-grey-opacity-50 border border-proton-grey-opacity-20 m-8 p-8">
-                    To function this app requires Algolia credentials. You must provide the Admin API Key for every feature to work properly.
-                </div>
-                <table>
-                    <tr class="text-left">
-                        <th class="p-8 text-xs uppercase tracking-wide font-normal">App ID</th>
-                        <th class="p-8 text-xs uppercase tracking-wide font-normal">Admin API Key</th>
-                        <th class="p-8 text-xs uppercase tracking-wide font-normal">App name</th>
-                        <th class="p-8 text-xs uppercase tracking-wide font-normal">App owner</th>
-                        <th class="p-8 text-xs uppercase tracking-wide font-normal"></th>
-                    </tr>
-                    <tr v-for="(app, appId) in apps" v-bind:key="appId">
-                        <td class="p-8">
-                            <a
-                                v-if="app.__app_uid"
-                                target="_blank"
-                                :href="`https://admin.algolia.com/admin/users/${app.__app_uid}/applications/${appId}`"
-                                class="text-nebula-blue cursor-pointer hover:underline"
-                            >
-                                {{appId}}
-                            </a>
-                            <span v-else>{{appId}}</span>
-                        </td>
-                        <td class="p-8">
-                            <edit-key :app-id="appId" key-name="key" />
-                        </td>
-                        <td class="p-8">{{app.__app_name}}</td>
-                        <td class="p-8">{{app.__app_owner}}</td>
-                        <td class="p-8">
-                            <trash-icon class="w-12 h-12 cursor-pointer" @click="deleteApp(appId)" />
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="p-8 pt-32">
-                            <input
-                                class="w-full bg-proton-grey-opacity-20 p-4"
-                                placeholder="appId"
-                                v-model="newAppId"
-                                @keyup.enter="addAppId"
-                            >
-                        </td>
-                        <td class="p-8 pt-32">
-                            <input
-                                class="w-full bg-proton-grey-opacity-20 p-4"
-                                placeholder="Admin apiKey"
-                                v-model="newApiKey"
-                                @keyup.enter="addAppId"
-                            >
-                        </td>
-                        <td class="p-8 pt-32">
-                            <button @click="addAppId">Add</button>
-                        </td>
-                    </tr>
-                </table>
-
+          </details>
+          <details
+            :open="currentTool == 'metaparams'"
+            class="mt-8"
+          >
+            <summary>Metaparams</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-proton-grey p-4 rounded">search</code> You can compare the query behavior between two known indices
+                </li>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">settings</code> (optional) You can check the settings, synonyms and rules for an index
+                </li>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">listIndices</code> (optional) You can see application stats.
+                </li>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">analytics</code> (optional) You can get top queries in the search bar.
+                </li>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">browse</code> (optional) You can switch the search bar mode to browse.
+                </li>
+                <li class="leading-normal">
+                  <code class="text-xs bg-mars-1 text-white p-4 rounded">setSettings</code> (optional) You can <em>modify</em> the settings, synonyms and rules for an index
+                </li>
+              </ul>
             </div>
+          </details>
+          <details
+            :open="currentTool == 'relevance-testing'"
+            class="mt-8"
+          >
+            <summary>Relevance testing</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-proton-grey p-4 rounded">search</code>
+                </li>
+              </ul>
+            </div>
+          </details>
+          <details
+            :open="currentTool == 'index-differ'"
+            class="mt-8"
+          >
+            <summary>Index Differ</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">settings</code> (optional) You can compare the settings, synonyms and rules between indices
+                </li>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">browse</code> (optional) You can compare the records between indices
+                </li>
+              </ul>
+            </div>
+          </details>
+          <details
+            :open="currentTool == 'logs'"
+            class="mt-8"
+          >
+            <summary>Realtime logs</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-saturn-1 text-white p-4 rounded">logs</code>
+                </li>
+              </ul>
+            </div>
+          </details>
+          <details
+            :open="currentTool == 'transform'"
+            class="mt-8"
+          >
+            <summary>Transform</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-proton-grey p-4 rounded">search</code>, <code class="text-xs bg-saturn-1 text-white p-4 rounded">browse</code> and <code class="text-xs bg-mars-1 text-white p-4 rounded">addObject</code>
+                </li>
+              </ul>
+            </div>
+          </details>
+          <details
+            :open="currentTool == 'index-analyzer'"
+            class="mt-8"
+          >
+            <summary>Index Analyzer</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-proton-grey p-4 rounded">search</code> and <code class="text-xs bg-saturn-1 text-white p-4 rounded">browse</code>
+                </li>
+              </ul>
+            </div>
+          </details>
+          <details
+            :open="currentTool == 'insights-ui'"
+            class="mt-8"
+          >
+            <summary>Insights UI</summary>
+            <div class="p-8">
+              <ul>
+                <li class="leading-normal">
+                  <code class="text-xs bg-proton-grey p-4 rounded">search</code> You can send events
+                </li>
+                <li class="leading-normal">
+                  <code class="text-xs bg-mars-1 text-white p-4 rounded">recommendation</code> (optional) You can send events based on Personalization's settings
+                </li>
+              </ul>
+            </div>
+          </details>
         </div>
+        <table>
+          <tr class="text-left">
+            <th class="p-8 text-xs uppercase tracking-wide font-normal">
+              App ID
+            </th>
+            <th class="p-8 text-xs uppercase tracking-wide font-normal">
+              API Key
+            </th>
+            <th class="p-8 text-xs uppercase tracking-wide font-normal">
+              Key type
+            </th>
+            <th class="p-8 text-xs uppercase tracking-wide font-normal">
+              App name
+            </th>
+            <th class="p-8 text-xs uppercase tracking-wide font-normal">
+              App owner
+            </th>
+            <th class="p-8 text-xs uppercase tracking-wide font-normal" />
+          </tr>
+          <tr
+            v-for="(app, appId) in apps"
+            :key="appId"
+          >
+            <td class="p-8">
+              <a
+                v-if="app.__app_uid"
+                target="_blank"
+                :href="`https://admin.algolia.com/admin/users/${app.__app_uid}/applications/${appId}`"
+                class="text-nebula-blue cursor-pointer hover:underline"
+              >
+                {{ appId }}
+              </a>
+              <span v-else>{{ appId }}</span>
+            </td>
+            <td class="p-8">
+              <edit-key
+                :app-id="appId"
+                key-name="key"
+              />
+            </td>
+            <td class="p-8">
+              {{ app.__app_name }}
+            </td>
+            <td class="p-8">
+              {{ app.__app_owner }}
+            </td>
+            <td class="p-8">
+              <trash-icon
+                class="w-12 h-12 cursor-pointer"
+                @click="deleteApp(appId)"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td class="p-8 pt-32">
+              <input
+                v-model="newAppId"
+                class="w-full bg-proton-grey-opacity-20 p-4"
+                placeholder="appId"
+                @keyup.enter="addAppId"
+              >
+            </td>
+            <td class="p-8 pt-32">
+              <input
+                v-model="newApiKey"
+                class="w-full bg-proton-grey-opacity-20 p-4"
+                placeholder="API Key"
+                @keyup.enter="addAppId"
+              >
+            </td>
+            <td class="p-8 pt-32">
+              <button @click="addAppId">
+                Add
+              </button>
+            </td>
+          </tr>
+        </table>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
@@ -84,17 +245,20 @@
                 newApiKey: "",
             }
         },
-        created: function () {
-            this.fetchAppsInfo();
-            this.$root.$on('onFetchAppsInfo', () => this.fetchAppsInfo());
-        },
         computed: {
             apps: function () {
                 return this.$store.state.apps;
             },
             appIds: function () {
                 return Object.keys(this.apps);
+            },
+            currentTool: function() {
+                return window.location.pathname.split("/")[1] || 'unknown'
             }
+        },
+        created: function () {
+            this.fetchAppsInfo();
+            this.$root.$on('onFetchAppsInfo', () => this.fetchAppsInfo());
         },
         methods: {
             addAppId: function() {

--- a/packages/common/components/selectors/CustomSelect.vue
+++ b/packages/common/components/selectors/CustomSelect.vue
@@ -1,56 +1,59 @@
 <template>
-    <div>
+  <div>
+    <div
+      class="relative focus:outline-none"
+      tabindex="-1"
+      @keyup="onKeyUp"
+      @keydown="onKeyDown"
+      @blur="fakeBlur"
+    >
+      <div
+        v-if="!dropdownOpened || !refine"
+        class="flex items-center py-4 cursor-pointer text-sm leading-none"
+        @click="openDropDown"
+      >
+        <slot name="icon" />
+        <slot
+          :option="value"
+          :in-drop-down="false"
+        />
+        <span class="ml-auto" />
+        <chevron-down-icon
+          class="block ml-24 w-8 h-8 fill-current"
+        />
+      </div>
+      <input
+        v-if="dropdownOpened && refine"
+        ref="input"
+        v-model="query"
+        class="px-8 py-4 text-solstice-blue rounded text-base bg-moon-grey w-full"
+        @keyup="onKeyUp"
+        @keydown="onKeyDown"
+        @blur="onBlur"
+      >
+      <div
+        v-if="dropdownOpened"
+        class="shadow absolute z-10 bg-white dropdown mt-4 max-h-312 min-w-full overflow-y-scroll"
+      >
         <div
-            class="relative focus:outline-none"
-            tabindex="-1"
-            @keyup="onKeyUp"
-            @keydown="onKeyDown"
-            @blur="fakeBlur"
+          v-for="(option, index) in options"
+          :class="`${selectedIndex === index ? 'bg-nebula-blue text-white hover:bg-nebula-blue hover:text-white' : ''}`"
+          class="flex p-8 cursor-pointer"
+          @mousedown="allowBlur = false"
+          @mousemove="selectedIndex = index"
+          @mouseleave="selectedIndex = -1"
+          @click="selectedIndex = index; onSelected($event); allowBlur = true;"
         >
-            <div
-                v-if="!dropdownOpened || !refine"
-                @click="openDropDown"
-                class="flex items-center py-4 cursor-pointer text-sm leading-none"
-            >
-                <slot name="icon" />
-                <slot v-bind:option="value" v-bind:inDropDown="false" />
-                <span class="ml-auto"></span>
-                <chevron-down-icon
-                    class="block ml-24 w-8 h-8 fill-current"
-                />
-            </div>
-            <input
-                v-if="dropdownOpened && refine"
-                ref="input"
-                class="px-8 py-4 text-solstice-blue rounded text-base bg-moon-grey w-full"
-                v-model="query"
-                @keyup="onKeyUp"
-                @keydown="onKeyDown"
-                @blur="onBlur"
-            />
-            <div
-                v-if="dropdownOpened"
-                class="shadow absolute z-10 bg-white dropdown mt-4 max-h-312 min-w-full overflow-y-scroll"
-            >
-                <div
-                    v-for="(option, index) in options"
-                    :class="`${selectedIndex === index ? 'bg-nebula-blue text-white hover:bg-nebula-blue hover:text-white' : ''}`"
-                    class="flex p-8 cursor-pointer"
-                    @mousedown="allowBlur = false"
-                    @mousemove="selectedIndex = index"
-                    @mouseleave="selectedIndex = -1"
-                    @click="selectedIndex = index; onSelected($event); allowBlur = true;"
-                >
-                    <slot
-                        v-bind:option="option"
-                        v-bind:inDropDown="true"
-                        v-bind:isSelected="selectedIndex === index"
-                        v-bind:highlightString="highlightString"
-                    />
-                </div>
-            </div>
+          <slot
+            :option="option"
+            :in-drop-down="true"
+            :is-selected="selectedIndex === index"
+            :highlight-string="highlightString"
+          />
         </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
@@ -60,8 +63,8 @@
 
     export default {
         name: 'CustomSelect',
-        props: ['value', 'options', 'displayEmptyQuery', 'refine', 'stringValueAttribute', 'allowFreeText'],
         components: {ChevronDownIcon},
+        props: ['value', 'options', 'displayEmptyQuery', 'refine', 'stringValueAttribute', 'allowFreeText'],
         data: function () {
             const value = this.stringValueAttribute && this.value ? this.value[this.stringValueAttribute] : this.value;
             return {
@@ -69,6 +72,11 @@
                 selectedIndex: -1,
                 dropdownOpened: false,
                 query: value || '',
+            }
+        },
+        computed: {
+            stringValue: function () {
+                return this.stringValueAttribute && this.value ? this.value[this.stringValueAttribute] : (this.value || '');
             }
         },
         watch: {
@@ -83,11 +91,6 @@
                 if (!this.refine) return;
 
                 this.query = this.stringValue;
-            }
-        },
-        computed: {
-            stringValue: function () {
-                return this.stringValueAttribute && this.value ? this.value[this.stringValueAttribute] : (this.value || '');
             }
         },
         methods: {

--- a/packages/css/copy-css.sh
+++ b/packages/css/copy-css.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 TARGET_DIRS=(
     "../apps/public/"
     "../index-differ/public/"

--- a/packages/index-analyzer/src/App.vue
+++ b/packages/index-analyzer/src/App.vue
@@ -1,45 +1,45 @@
 <template>
-    <internal-app>
-        <div class="min-h-screen pb-48">
-            <app-header app-name="Index Analyzer">
-                <display-config class="mt-0 ml-auto" />
-            </app-header>
-            <div class="px-48 mt-24">
-                <app-management @onAddedAppId="appId = $event" />
-                <div class="max-w-960 mx-auto mt-24">
-                    <div class="rounded border border-proton-grey-opacity-60 mt-24">
-                        <div class="flex bg-white p-8 pb-12 bg-proton-grey-opacity-40 text-telluric-blue">
-                            <app-selector v-model="appId" />
-                            <index-selector
-                                v-model="indexName"
-                                :app-id="appId"
-                                class="ml-24"
-                                allow-free-text="true"
-                            />
-                            <div class="flex flex-grow">
-                                <input placeholder="attributeName" class="rounded ml-24 px-8 max-w-third flex-grow" v-model="attributeName" />
-                                <input v-if="attributeName.length > 0" placeholder="type" class="rounded ml-24 px-8 max-w-third flex-grow" v-model="typeFilter" />
-                                <input v-if="attributeName.length > 0" placeholder="value" class="rounded ml-24 px-8 max-w-third flex-grow" v-model="valueFilter" />
-                            </div>
-                        </div>
-                        <div class="bg-white text-nova-grey">
-                            <metrics
-                                :app-id="appId"
-                                :index-name="indexName"
-                                :attribute-name="attributeName"
-                                :attributes="attributes"
-                                :typeFilter="typeFilter"
-                                :valueFilter="valueFilter"
-                                @onUpdateAttributeName="attributeName = $event"
-                                @onUpdateValueFilter="valueFilter = $event"
-                                @onUpdateTypeFilter="typeFilter = $event"
-                            />
-                        </div>
-                    </div>
-                </div>
+  <internal-app>
+    <div class="min-h-screen pb-48">
+      <app-header app-name="Index Analyzer">
+        <display-config class="mt-0 ml-auto" />
+      </app-header>
+      <div class="px-48 mt-24">
+        <app-management @onAddedAppId="appId = $event" />
+        <div class="max-w-960 mx-auto mt-24">
+          <div class="rounded border border-proton-grey-opacity-60 mt-24">
+            <div class="flex bg-white p-8 pb-12 bg-proton-grey-opacity-40 text-telluric-blue">
+              <app-selector v-model="appId" />
+              <index-selector
+                v-model="indexName"
+                :app-id="appId"
+                class="ml-24"
+                allow-free-text="true"
+              />
+              <div class="flex flex-grow">
+                <input placeholder="attributeName" class="rounded ml-24 px-8 max-w-third flex-grow" v-model="attributeName" />
+                <input v-if="attributeName.length > 0" placeholder="type" class="rounded ml-24 px-8 max-w-third flex-grow" v-model="typeFilter" />
+                <input v-if="attributeName.length > 0" placeholder="value" class="rounded ml-24 px-8 max-w-third flex-grow" v-model="valueFilter" />
+              </div>
             </div>
+            <div class="bg-white text-nova-grey">
+              <metrics
+                :app-id="appId"
+                :index-name="indexName"
+                :attribute-name="attributeName"
+                :attributes="attributes"
+                :typeFilter="typeFilter"
+                :valueFilter="valueFilter"
+                @onUpdateAttributeName="attributeName = $event"
+                @onUpdateValueFilter="valueFilter = $event"
+                @onUpdateTypeFilter="typeFilter = $event"
+              />
+            </div>
+          </div>
         </div>
-    </internal-app>
+      </div>
+    </div>
+  </internal-app>
 </template>
 
 <script>

--- a/packages/index-analyzer/src/App.vue
+++ b/packages/index-analyzer/src/App.vue
@@ -14,6 +14,7 @@
                                 v-model="indexName"
                                 :app-id="appId"
                                 class="ml-24"
+                                allow-free-text="true"
                             />
                             <div class="flex flex-grow">
                                 <input placeholder="attributeName" class="rounded ml-24 px-8 max-w-third flex-grow" v-model="attributeName" />

--- a/packages/index-differ/src/App.vue
+++ b/packages/index-differ/src/App.vue
@@ -12,7 +12,7 @@
                         <div class="flex items-center w-full justify-between p-12 pb-8">
                             <div class="flex">
                                 <app-selector v-model="refIndexInfo.appId" class="mb-4" />
-                                <index-selector v-model="refIndexInfo.indexName" :app-id="refIndexInfo.appId" class="ml-12 mb-4" />
+                                <index-selector v-model="refIndexInfo.indexName" :app-id="refIndexInfo.appId" class="ml-12 mb-4" allow-free-text="true"/>
                             </div>
                         </div>
                     </div>
@@ -93,7 +93,7 @@
                                 <div class="flex w-full justify-between p-16">
                                     <div class="flex w-full items-center">
                                         <app-selector v-model="indexInfo.appId" class="mb-4" />
-                                        <index-selector v-model="indexInfo.indexName" :app-id="indexInfo.appId" class="ml-12 mb-4" />
+                                        <index-selector v-model="indexInfo.indexName" :app-id="indexInfo.appId" class="ml-12 mb-4" allow-free-text="true"/>
                                         <swap-icon
                                             @click="swapIndex(i)"
                                             class="ml-auto rotate-90 -mt-8 w-16 h-16 cursor-pointer text-solstice-blue"

--- a/packages/insights-ui/src/App.vue
+++ b/packages/insights-ui/src/App.vue
@@ -9,7 +9,7 @@
                 <div class="bg-white rounded border border-proton-grey-opacity-60">
                     <div class="flex bg-white p-8 pb-12 border-nova-grey-opacity-20 bg-proton-grey-opacity-80 text-telluric-blue">
                         <app-selector v-model="appId" class="mr-16" />
-                        <index-selector v-model="indexName" :app-id="appId" class="" allow-free-text="true"/>
+                        <index-selector v-model="indexName" :app-id="appId" class="" allow-free-text="true" />
                     </div>
                     <div v-if="indexData && this.apiKey">
                         <div class="flex bg-proton-grey-opacity-40 text-telluric-blue">

--- a/packages/insights-ui/src/App.vue
+++ b/packages/insights-ui/src/App.vue
@@ -9,7 +9,7 @@
                 <div class="bg-white rounded border border-proton-grey-opacity-60">
                     <div class="flex bg-white p-8 pb-12 border-nova-grey-opacity-20 bg-proton-grey-opacity-80 text-telluric-blue">
                         <app-selector v-model="appId" class="mr-16" />
-                        <index-selector v-model="indexName" :app-id="appId" class="" />
+                        <index-selector v-model="indexName" :app-id="appId" class="" allow-free-text="true"/>
                     </div>
                     <div v-if="indexData && this.apiKey">
                         <div class="flex bg-proton-grey-opacity-40 text-telluric-blue">

--- a/packages/logs/src/App.vue
+++ b/packages/logs/src/App.vue
@@ -34,6 +34,7 @@
                             :app-id="appId"
                             :forced-indices="[{name: 'All Indices'}]"
                             class="mr-16"
+                            allow-free-text="true"
                         />
                         <custom-select
                             v-model="logsType"

--- a/packages/metaparams/src/dashboard/Dashboard.vue
+++ b/packages/metaparams/src/dashboard/Dashboard.vue
@@ -26,6 +26,7 @@
             v-model="indexName"
             :app-id="appId"
             class="ml-12 mb-12"
+            allow-free-text="true"
           />
           <user-selector
             v-model="panelUserId"

--- a/packages/metaparams/src/dashboard/IndexInfo.vue
+++ b/packages/metaparams/src/dashboard/IndexInfo.vue
@@ -130,31 +130,38 @@
             fetchIndexData: async function (indexName) {
                 if (!this.indexData) return;
 
-                const client = await getClient(this.panelAppId, this.panelAdminAPIKey, this.panelServer);
-                const res = await client.listIndices({
-                    queryParameters: {
-                        page: 0, prefix: indexName
-                    }
-                });
+                try {
+                    const client = await getClient(this.panelAppId, this.panelAdminAPIKey, this.panelServer);
+                    const res = await client.listIndices({
+                        queryParameters: {
+                            page: 0, prefix: indexName
+                        }
+                    });
 
-                res.items.forEach((indexInfo) => {
-                    if (indexInfo.name === indexName) {
-                        this.indexInfo = indexInfo;
-                    }
-                });
+                    res.items.forEach((indexInfo) => {
+                        if (indexInfo.name === indexName) {
+                            this.indexInfo = indexInfo;
+                        }
+                    });
 
-                this.$emit('onUpdateHasNoRecord', this.indexInfo !== null && this.indexInfo.entries === 0);
+                    this.$emit('onUpdateHasNoRecord', this.indexInfo !== null && this.indexInfo.entries === 0);
+                } catch(e) {
+                    console.warn("listIndices ignored due to apiKey restrictions", e)
+                }
             },
             fetchBuildingIndices: async function () {
                 if (!this.indexData) return;
 
-                const client = await getClient(this.panelAppId, this.panelAdminAPIKey, this.panelServer);
-                const data = await client.transporter.write({
-                    method: 'GET',
-                    path: '1/indexes/*/stats',
-                });
-
-                this.buildingIndices = data.building;
+                try {
+                    const client = await getClient(this.panelAppId, this.panelAdminAPIKey, this.panelServer);
+                    const data = await client.transporter.write({
+                        method: 'GET',
+                        path: '1/indexes/*/stats',
+                    });
+                    this.buildingIndices = data.building;
+                } catch(e) {
+                    console.warn("buildingIndices call ignored due to apiKey restrictions", e)
+                }
             }
         }
     }

--- a/packages/metaparams/src/queries/queries.vue
+++ b/packages/metaparams/src/queries/queries.vue
@@ -106,24 +106,28 @@
             fetchTopQueries: async function () {
                 this.topQueries = [];
 
-                const topQueriesQuery = await fetch(`https://analytics.${this.region}.algolia.com/2/searches?index=${this.panelIndexName}&limit=100`, {
-                    headers: {
-                        'X-Algolia-Application-Id': this.panelAppId,
-                        'X-Algolia-API-Key': this.panelAdminAPIKey,
-                    }
-                });
+                try {
+                    const topQueriesQuery = await fetch(`https://analytics.${this.region}.algolia.com/2/searches?index=${this.panelIndexName}&limit=100`, {
+                        headers: {
+                            'X-Algolia-Application-Id': this.panelAppId,
+                            'X-Algolia-API-Key': this.panelAdminAPIKey,
+                        }
+                    });
 
-                if (topQueriesQuery.status !== 200) return;
+                    if (topQueriesQuery.status !== 200) return;
 
-                const topQueries = await topQueriesQuery.json();
+                    const topQueries = await topQueriesQuery.json();
 
-                if (topQueries.searches === null) return;
+                    if (topQueries.searches === null) return;
 
-                this.topQueries = topQueries.searches.filter((query) => {
-                    return query.search.length > 0;
-                }).map((query) => {
-                    return query.search;
-                });
+                    this.topQueries = topQueries.searches.filter((query) => {
+                        return query.search.length > 0;
+                    }).map((query) => {
+                        return query.search;
+                    });
+                } catch (e) {
+                    console.warn('fetchTopQueries ignored due to apiKey restrictions', e)
+                }
             },
             goToQuery: function (query) {
                 this.lastQueryJustSaved = true;

--- a/packages/relevance-testing/src/relevance-testing/run/EditRun.vue
+++ b/packages/relevance-testing/src/relevance-testing/run/EditRun.vue
@@ -2,7 +2,7 @@
     <div class="p-8 h-full text-telluric-blue text-sm">
         <div class="flex flex-col h-full">
             <app-selector v-model="run.app_id" />
-            <index-selector v-model="run.index_name" :app-id="run.app_id" />
+            <index-selector v-model="run.index_name" :app-id="run.app_id" allow-free-text="true"/>
             <div class="flex my-12">
                 <div>Page size:</div>
                 <input v-model="run.hits_per_page" type="number" min="1" max="1000" class="input-custom ml-8" />

--- a/packages/transform/src/DatasetSelector.vue
+++ b/packages/transform/src/DatasetSelector.vue
@@ -83,6 +83,7 @@
                         v-model="indexInfo.indexName"
                         :app-id="indexInfo.appId"
                         class="ml-24"
+                        allow-free-text="true"
                     />
                     <div class="flex ml-48">
                         Fetch extra record:


### PR DESCRIPTION
**What**

This PR reworks the UI of the apps panel to provide API Key recommendations with the least amount of privileges based on the tool the user wants to use.

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/4c675ea3-89c0-4e82-96b0-187fee135aef">


**Nice to have**: Depending on the tool in which the application panel is open, different sections are opened by default

<img width="1205" alt="image" src="https://github.com/user-attachments/assets/50c35d3e-9877-444a-9257-cae847f6c6c1">
