### PR TITLE
Set default resource settings to false

### DIFF
--- a/packages/transform/src/Applier.vue
+++ b/packages/transform/src/Applier.vue
@@ -111,9 +111,9 @@ export default {
             copySettings: false,
             copyResources: {
                 partial: false,
-                settings: true,
-                synonyms: true,
-                rules: true,
+                settings: false,
+                synonyms: false,
+                rules: false,
             },
         }
     },


### PR DESCRIPTION
I added "Copy additional index resources" to the transform tool but the settings were true default. It's better that they be false unless specified otherwise. Here is a Slack thread to provide further detail: https://algolia.slack.com/archives/G01FCCFPD34/p1731538670167539