### PR TITLE
chore: upgrade node (for real)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
         "test": "yarn jest"
     },
     "engines": {
-        "node": ">=14.x <=18.x"
+        "node": "18.x"
     }
 }


### PR DESCRIPTION
With the ranges set previously (don't know why) the version being used by Heroku were in reality v17. This makes sure we are using v18

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/4ab77e1e-6809-4fb7-8e3b-f3154179003b">
