### PR TITLE
chore(metaparams): add search extensions/workflowSelector support

### DIFF
--- a/packages/common/components/autocomplete/AlgoliaAutocomplete.vue
+++ b/packages/common/components/autocomplete/AlgoliaAutocomplete.vue
@@ -1,39 +1,83 @@
 <template>
-    <div>
-        <autocomplete
-            ref="autocomplete"
-            :items="items"
-            :refine="refine"
-            :value="value"
-            :display-empty-query="displayEmptyQuery"
-            :empty-search-for-query-equals-value="true"
-            v-on="$listeners"
+  <div>
+    <autocomplete
+      ref="autocomplete"
+      :items="items"
+      :refine="refine"
+      :value="value"
+      :display-empty-query="displayEmptyQuery"
+      :empty-search-for-query-equals-value="true"
+      v-on="$listeners"
+    >
+      <template #item="{ index, item }">
+        <slot
+          :index="index"
+          :item="item"
         >
-            <template v-slot:item="{ index, item }">
-                <slot v-bind:index="index" v-bind:item="item">
-                    <!-- XSS Check: all values are being constructed using `escapeHtml` -->
-                    <div
-                        v-html="item._highlightResult[displayAttributeName] ? unescapeEm(escapeHtml(item._highlightResult[displayAttributeName].value)): escapeHtml(item[displayAttributeName])"
-                    >
-                    </div>
-                </slot>
-            </template>
-        </autocomplete>
-    </div>
+          <div>
+            <span
+              v-for="(part, partIndex) in highlightParts(item)"
+              :key="partIndex"
+              :class="{ 'font-bold': part.highlighted }"
+            >
+              {{ part.value }}
+            </span>
+          </div>
+        </slot>
+      </template>
+    </autocomplete>
+  </div>
 </template>
 
 <script>
 import Autocomplete from "./Autocomplete.vue";
 import algoliasearch from "algoliasearch";
-import {escapeHtml, unescapeEm} from "common/utils/formatters";
 
 export default {
     name: 'AlgoliaAutocomplete',
     components: {Autocomplete},
-    props: ['indexName', 'searchParams', 'displayAttributeName', 'value', 'displayEmptyQuery', 'appId', 'apiKey'],
+    props: {
+        indexName: {
+            type: String,
+            default: '',
+        },
+        searchParams: {
+            type: Object,
+            default: function () {
+                return {};
+            },
+        },
+        displayAttributeName: {
+            type: String,
+            default: '',
+        },
+        value: {
+            type: [String, Number, Object],
+            default: '',
+        },
+        displayEmptyQuery: {
+            type: Boolean,
+            default: false,
+        },
+        appId: {
+            type: String,
+            default: '',
+        },
+        apiKey: {
+            type: String,
+            default: '',
+        },
+        localItems: {
+            type: Array,
+            default: function () {
+                return [];
+            },
+        },
+    },
     data: function () {
         return {
-            items: []
+            items: [],
+            refineRequestId: 0,
         }
     },
     computed: {
@@ -41,16 +85,76 @@ export default {
             return algoliasearch(this.appId, this.apiKey).initIndex(this.indexName)
         }
     },
-    methods: {
-        refine: async function (query) {
-            const data = await this.algoliaIndex.search(query, this.searchParams || {});
-            this.items = data.hits;
-        },
-        escapeHtml,
-        unescapeEm,
-    },
     created: function () {
         this.refine('');
+    },
+    methods: {
+        localRefine: function (query) {
+            const normalizedQuery = (query || '').toLowerCase();
+            if (!normalizedQuery && !this.displayEmptyQuery) return [];
+            const hitsPerPage = ((this.searchParams || {}).hitsPerPage || 20);
+            return (this.localItems || []).filter((item) => {
+                const value = item[this.displayAttributeName] || item.name || item.param_name || '';
+                return value.toLowerCase().includes(normalizedQuery);
+            }).sort((a, b) => {
+                const aValue = (a[this.displayAttributeName] || a.name || a.param_name || '').toLowerCase();
+                const bValue = (b[this.displayAttributeName] || b.name || b.param_name || '').toLowerCase();
+                const aStartsWith = aValue.startsWith(normalizedQuery);
+                const bStartsWith = bValue.startsWith(normalizedQuery);
+                if (aStartsWith !== bStartsWith) return aStartsWith ? -1 : 1;
+                if (aValue.length !== bValue.length) return aValue.length - bValue.length;
+                return aValue.localeCompare(bValue);
+            }).slice(0, hitsPerPage);
+        },
+        itemKey: function (item) {
+            return item.param_name || item.name || item[this.displayAttributeName];
+        },
+        mergeItems: function (localItems, remoteItems) {
+            const keys = new Set();
+            return [...localItems, ...remoteItems].filter((item) => {
+                const key = this.itemKey(item);
+                if (keys.has(key)) return false;
+                keys.add(key);
+                return true;
+            });
+        },
+        highlightParts: function (item) {
+            const highlightedValue = item._highlightResult &&
+                item._highlightResult[this.displayAttributeName] &&
+                item._highlightResult[this.displayAttributeName].value;
+            const value = highlightedValue || item[this.displayAttributeName] || '';
+            return String(value)
+                .split(/(<\/?em>)/)
+                .reduce((parts, part) => {
+                    const lastPart = parts[parts.length - 1];
+                    if (part === '<em>') {
+                        parts.push({value: '', highlighted: true});
+                    } else if (part === '</em>') {
+                        parts.push({value: '', highlighted: false});
+                    } else if (part) {
+                        if (lastPart) {
+                            lastPart.value += part;
+                        } else {
+                            parts.push({value: part, highlighted: false});
+                        }
+                    }
+                    return parts;
+                }, [{value: '', highlighted: false}])
+                .filter((part) => part.value);
+        },
+        refine: async function (query) {
+            const requestId = ++this.refineRequestId;
+            const localItems = this.localRefine(query);
+            this.items = localItems;
+            try {
+                const data = await this.algoliaIndex.search(query, this.searchParams || {});
+                if (requestId !== this.refineRequestId) return;
+                this.items = this.mergeItems(localItems, data.hits);
+            } catch (e) {
+                if (requestId !== this.refineRequestId) return;
+                this.items = localItems;
+            }
+        },
     },
 }
 </script>

--- a/packages/common/components/explorer/export-params/snippet-generator.js
+++ b/packages/common/components/explorer/export-params/snippet-generator.js
@@ -22,6 +22,7 @@ const SnippetGenerator = function () {
                 .replace(/__METHOD__/g, dedent(templates[config.method][config.language]))
                 .replace(/__QUERY__/g, query)
                 .replace(/__PARAMS__/g, this.params_template(config))
+                .replace(/__CURL_SEARCH_BODY__/g, this.curlSearchBody(config))
                 .replace(/__APP_ID__/g, config.appId)
                 .replace(/__API_KEY__/g, config.apiKey)
                 .replace(/__INDEX_NAME__/g, config.indexName);
@@ -35,12 +36,15 @@ const SnippetGenerator = function () {
         }
 
         const params = Object.keys(config.params).map((key) => {
+            if (config.language === 'curl' && key === 'extensions') {
+                return '';
+            }
             const value = this.getStringValue(config.params[key], config.language);
             if (config.language === 'php') {
-                return `    '${key}': ${value}`;
+                return `    '${key}' => ${value}`;
             }
             if (config.language === 'ruby') {
-                return `    :${key}: ${value}`;
+                return `    ${key}: ${value}`;
             }
             if (config.language === 'python') {
                 return `    "${key}": ${value}`;
@@ -58,22 +62,93 @@ const SnippetGenerator = function () {
         return params.join('');
     };
 
-    this.getStringValue = function (value, language) {
+    this.curlParamValue = function (value) {
+        if (Array.isArray(value) || (value && typeof value === 'object')) {
+            return JSON.stringify(value);
+        }
+        return value;
+    };
+
+    this.curlSearchBody = function (config) {
+        const params = Object.keys(config.params)
+            .filter((key) => key !== 'extensions')
+            .map((key) => {
+                return `&${key}=${encodeURIComponent(this.curlParamValue(config.params[key]))}`;
+            })
+            .join('');
+
+        const body = {
+            params: `query=${encodeURIComponent(config.query)}${params}`,
+        };
+
+        if (config.params.extensions !== undefined) {
+            body.extensions = config.params.extensions;
+        }
+
+        return this.escapeBashSingleQuotedString(JSON.stringify(body));
+    };
+
+    this.escapeBashSingleQuotedString = function (value) {
+        return value.split("'").join("'\\''");
+    };
+
+    this.getQuotedString = function (value, quote) {
+        return `${quote}${String(value).replace(/\\/g, '\\\\').split(quote).join(`\\${quote}`)}${quote}`;
+    };
+
+    this.getObjectKey = function (key, language) {
+        if (language === 'php') return `'${key}' =>`;
+        if (language === 'ruby') return `${key}:`;
+        if (language === 'python') return `"${key}":`;
+        return `${key}:`;
+    };
+
+    this.getNullValue = function (language) {
+        if (language === 'python') return 'None';
+        if (language === 'ruby') return 'nil';
+        return 'null';
+    };
+
+    this.getBooleanValue = function (value, language) {
+        if (language === 'python') return value ? 'True' : 'False';
+        return value ? 'true' : 'false';
+    };
+
+    this.getStringValue = function (value, language, indentLevel = 1) {
         if (isString(value)) {
-            if (language === 'python') return `"${value}"`;
-            return `'${value}'`;
+            if (language === 'python') return this.getQuotedString(value, '"');
+            return this.getQuotedString(value, "'");
+        }
+
+        if (value === null) {
+            return this.getNullValue(language);
         }
 
         if (typeof value === "boolean") {
-            return value;
+            return this.getBooleanValue(value, language);
         }
 
-        if (Number.isInteger(value)) {
+        if (typeof value === 'number') {
             return value;
         }
 
         if (Array.isArray(value)) {
-            return `[\n      ${value.map((v) => this.getStringValue(v, language)).join(',\n      ')}\n    ]`;
+            if (value.length === 0) return '[]';
+            const indent = '    '.repeat(indentLevel);
+            const childIndent = '    '.repeat(indentLevel + 1);
+            return `[\n${childIndent}${value.map((v) => this.getStringValue(v, language, indentLevel + 1)).join(`,\n${childIndent}`)}\n${indent}]`;
+        }
+
+        if (value && typeof value === 'object') {
+            const open = language === 'php' ? '[' : '{';
+            const close = language === 'php' ? ']' : '}';
+            if (Object.keys(value).length === 0) return `${open}${close}`;
+            const indent = '    '.repeat(indentLevel);
+            const childIndent = '    '.repeat(indentLevel + 1);
+            const entries = Object.keys(value).map((key) => {
+                return `${childIndent}${this.getObjectKey(key, language)} ${this.getStringValue(value[key], language, indentLevel + 1)}`;
+            });
+            return `${open}\n${entries.join(',\n')}\n${indent}${close}`;
         }
     };
 };

--- a/packages/common/components/explorer/export-params/templates.js
+++ b/packages/common/components/explorer/export-params/templates.js
@@ -86,7 +86,7 @@ export default {
             curl -X POST \\
             -H "X-Algolia-Application-Id: __APP_ID__" \\
             -H "X-Algolia-API-Key: __API_KEY__" \\
-            --data-binary '{ "params": "query=__QUERY____PARAMS__" }' \\
+            --data-binary '__CURL_SEARCH_BODY__' \\
             "https://__APP_ID__-dsn.algolia.net/1/indexes/__INDEX_NAME__/query"
         `
     },

--- a/packages/common/components/params/input/InputExtensions.vue
+++ b/packages/common/components/params/input/InputExtensions.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="w-full max-w-full">
+    <div class="flex items-center gap-4">
+      <span class="text-xs text-proton-grey whitespace-nowrap">workflowSelector.name</span>
+      <input
+        ref="workflowNameInput"
+        v-model="workflowName"
+        class="input-custom min-w-0 flex-1 text-xs p-4"
+        placeholder="your_workflow_name"
+        @keydown.enter.prevent="inputState.setInput('none')"
+        @blur="onBlur"
+      >
+      <button
+        type="button"
+        class="bg-white border border-proton-grey-opacity-40 rounded px-8 p-4 text-xs shadow-sm hover:shadow transition-fast-out"
+        @click="toggleJsonMode"
+      >
+        {{ showJson ? 'Form' : 'JSON' }}
+      </button>
+    </div>
+    <div
+      v-if="showJson"
+      class="mt-4"
+    >
+      <textarea
+        v-model="draft"
+        class="input-custom w-full max-w-full font-mono text-xs leading-tight p-8"
+        rows="6"
+        @input="onJsonInput"
+        @keydown.tab.prevent
+        @blur="onBlur"
+      />
+      <div
+        v-if="error"
+        class="text-mars-1 text-xs mt-4"
+      >
+        {{ error }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import inputMixin from "../scripts/inputMixin";
+
+const defaultExtensions = function () {
+    return {
+        workflowSelector: {
+            name: '',
+        },
+    };
+};
+
+const extensionsValue = function (value) {
+    return value || defaultExtensions();
+};
+
+const setWorkflowName = function (value, name) {
+    return {
+        ...(value || {}),
+        workflowSelector: {
+            ...((value || {}).workflowSelector || {}),
+            name,
+        },
+    };
+};
+
+export default {
+    name: 'InputExtensions',
+    mixins: [inputMixin],
+    data: function () {
+        return {
+            draft: JSON.stringify(extensionsValue(this.value), null, 2),
+            error: '',
+            showJson: false,
+        };
+    },
+    computed: {
+        workflowName: {
+            get: function () {
+                return ((this.value || {}).workflowSelector || {}).name || '';
+            },
+            set: function (name) {
+                const nextValue = setWorkflowName(this.value, name);
+                this.value = nextValue;
+                this.draft = JSON.stringify(nextValue, null, 2);
+                this.error = '';
+            },
+        },
+    },
+    watch: {
+        value: function (value) {
+            if (this.showJson) return;
+            const serialized = JSON.stringify(extensionsValue(value), null, 2);
+            if (serialized !== this.draft) {
+                this.draft = serialized;
+            }
+        },
+    },
+    mounted: function () {
+        if (this.$refs.workflowNameInput) {
+            this.$refs.workflowNameInput.focus();
+            this.$refs.workflowNameInput.select();
+        }
+    },
+    methods: {
+        toggleJsonMode: function () {
+            this.showJson = !this.showJson;
+            if (this.showJson) {
+                this.draft = JSON.stringify(extensionsValue(this.value), null, 2);
+            }
+        },
+        onJsonInput: function () {
+            try {
+                const parsed = JSON.parse(this.draft);
+                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                    this.error = 'Expected a JSON object.';
+                    return;
+                }
+                this.error = '';
+                this.value = parsed;
+            } catch (e) {
+                this.error = e.message;
+            }
+        },
+    },
+}
+</script>

--- a/packages/common/components/params/input/InputJsonObject.vue
+++ b/packages/common/components/params/input/InputJsonObject.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="w-full">
+    <textarea
+      ref="input"
+      v-model="draft"
+      class="input-custom w-full max-w-full font-mono text-xs leading-tight p-8"
+      rows="6"
+      @focus="onFocus"
+      @input="onInput"
+      @keydown.tab.prevent
+      @blur="onBlur"
+    />
+    <div
+      v-if="error"
+      class="text-mars-1 text-xs mt-4"
+    >
+      {{ error }}
+    </div>
+  </div>
+</template>
+
+<script>
+import inputMixin from "../scripts/inputMixin";
+
+export default {
+    name: 'InputJsonObject',
+    mixins: [inputMixin],
+    data: function () {
+        return {
+            draft: JSON.stringify(this.value || {}, null, 2),
+            error: '',
+            isEditing: false,
+        };
+    },
+    watch: {
+        value: function (value) {
+            if (this.isEditing) return;
+            const serialized = JSON.stringify(value || {}, null, 2);
+            if (serialized !== this.draft) {
+                this.draft = serialized;
+            }
+        },
+    },
+    mounted: function () {
+        if (this.$refs.input) {
+            this.$refs.input.focus();
+            this.$refs.input.setSelectionRange(0, this.draft.length);
+        }
+    },
+    methods: {
+        parseDraft: function () {
+            try {
+                const parsed = JSON.parse(this.draft);
+                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                    this.error = 'Expected a JSON object.';
+                    return null;
+                }
+                this.error = '';
+                return parsed;
+            } catch (e) {
+                this.error = e.message;
+                return null;
+            }
+        },
+        onFocus: function () {
+            this.isEditing = true;
+        },
+        onInput: function () {
+            this.isEditing = true;
+            const parsed = this.parseDraft();
+            if (parsed) {
+                this.value = parsed;
+            }
+        },
+        onBlur: function () {
+            this.isEditing = false;
+            const parsed = this.parseDraft();
+            if (parsed) {
+                this.value = parsed;
+                this.inputState.setInput('none');
+            }
+        },
+    },
+}
+</script>

--- a/packages/common/components/params/input/InputParamName.vue
+++ b/packages/common/components/params/input/InputParamName.vue
@@ -22,6 +22,7 @@
       :display-empty-query="inputKey !== 'root'"
       display-attribute-name="camel_case_label"
       :search-params="{ hitsPerPage: 4, ...searchFilters }"
+      :local-items="localParamItems"
       @onSelected="onSelected"
       @onBlur="inputState.setInput('none')"
     />
@@ -35,6 +36,14 @@ import inputMixin from "../scripts/inputMixin";
 
 const isObject = function (obj) {
     return obj && typeof obj === 'object' && obj.constructor === Object;
+};
+
+const cloneDefault = function (paramName) {
+    return JSON.parse(JSON.stringify(paramsSpecs[paramName].default));
+};
+
+const specHasScope = function (spec, scope) {
+    return Array.isArray(spec.scope) ? spec.scope.includes(scope) : spec.scope === scope;
 };
 
 export default {
@@ -57,6 +66,20 @@ export default {
                 return { filters: 'scope:search' }
             }
             return { filters: 'scope:settings' }
+        },
+        localParamItems: function () {
+            const scope = this.configKey.startsWith('searchParams') ? 'search' : 'settings';
+            return Object.keys(paramsSpecs).filter((paramName) => {
+                return specHasScope(paramsSpecs[paramName], scope);
+            }).map((paramName) => {
+                return {
+                    ...paramsSpecs[paramName],
+                    name: paramName,
+                    param_name: paramName,
+                    type: 'param',
+                    camel_case_label: paramName,
+                };
+            });
         },
     },
     methods: {
@@ -110,6 +133,10 @@ export default {
                     }
                 }
                 else {
+                    if (paramsSpecs[selected]) {
+                        this.setParamValue(selected, cloneDefault(selected));
+                        return this.inputState.setInput(selected);
+                    }
                     this.setParamValue(selected, '');
                     return this.inputState.setInput(selected);
                 }

--- a/packages/common/components/params/input/InputValue.vue
+++ b/packages/common/components/params/input/InputValue.vue
@@ -26,6 +26,8 @@
     import InputDecompoundedAttributes from "./InputDecompoundedAttributes.vue";
     import InputIntegerSlider from "./InputIntegerSlider.vue";
     import InputDevFeatureFlags from "./InputDevFeatureFlags.vue";
+    import InputJsonObject from "./InputJsonObject.vue";
+    import InputExtensions from "./InputExtensions.vue";
 
     export default {
         name: 'InputValue',
@@ -45,7 +47,9 @@
                     filters: InputFilters,
                     param_name: InputParamName,
                     decompounded_attributes: InputDecompoundedAttributes,
-                    dev_feature_flags: InputDevFeatureFlags
+                    dev_feature_flags: InputDevFeatureFlags,
+                    json_object: InputJsonObject,
+                    extensions: InputExtensions,
                 }
             }
         },

--- a/packages/common/params-specs/data.yml
+++ b/packages/common/params-specs/data.yml
@@ -1300,6 +1300,15 @@ enableABTest:
     - false
   default: true
 
+extensions:
+  scope:
+    - search
+  value_type: object
+  object_type: extensions
+  default:
+    workflowSelector:
+      name: ""
+
 decompoundedAttributes:
   scope:
     - settings

--- a/packages/common/utils/curlCommandExtractor.js
+++ b/packages/common/utils/curlCommandExtractor.js
@@ -1,7 +1,21 @@
 import parseArgsStringToArgv from "string-argv";
 import paramsSpecs from "common/params-specs/data.yml";
 
-const isFakeArray = (val) => val.startsWith("[") && val.endsWith("]");
+const isSerializedJsonParam = (val) => {
+    return (
+        (val.startsWith("[") && val.endsWith("]")) ||
+        (val.startsWith("{") && val.endsWith("}"))
+    );
+};
+
+const parseJsonParam = (val) => {
+    if (!isSerializedJsonParam(val)) return null;
+    try {
+        return JSON.parse(val);
+    } catch (e) {
+        return null;
+    }
+};
 
 /**
  * Converts escaped JSON strings into unescaped JSON.
@@ -38,8 +52,9 @@ const decode = function (data) {
         if (key === "params") {
             return Object.fromEntries(
                 [...new URLSearchParams(val)].map(([k, v]) => {
-                    if (isFakeArray(v)) {
-                        return [k, JSON.parse(v)];
+                    const parsedJsonParam = parseJsonParam(v);
+                    if (parsedJsonParam !== null) {
+                        return [k, parsedJsonParam];
                     }
                     return [k, castValue(k, v)];
                 })
@@ -96,9 +111,10 @@ export function parseCurlCommand(command) {
                 if (i >= argv.length) break;
                 const headerString = argv[i];
                 const split = headerString.split(": ");
-                if (split[0] === "x-algolia-user-token")
+                const headerName = split[0].toLowerCase();
+                if (headerName === "x-algolia-user-token")
                     params.userToken = split[1];
-                if (split[0] === "x-algolia-application-id") appId = split[1];
+                if (headerName === "x-algolia-application-id") appId = split[1];
                 continue;
             }
             if (["-d", "--data", "--data-binary", "--data-raw"].includes(arg)) {
@@ -122,6 +138,9 @@ export function parseCurlCommand(command) {
                 if (request.params) {
                     params = request.params;
                 }
+                if (request.extensions) {
+                    params.extensions = request.extensions;
+                }
             } else {
                 const matches = pathName.match(/\/1\/indexes\/(.*?)\/query/);
                 if (matches) {
@@ -130,6 +149,9 @@ export function parseCurlCommand(command) {
                         params = data.params;
                     } else {
                         params = data;
+                    }
+                    if (data.extensions) {
+                        params.extensions = data.extensions;
                     }
                 }
             }

--- a/packages/common/utils/customIndexMethods.js
+++ b/packages/common/utils/customIndexMethods.js
@@ -12,6 +12,14 @@ const getNewParams = function (params) {
     return newQuery;
 };
 
+const splitExtensions = function (params) {
+    const {extensions, ...paramsWithoutExtensions} = params;
+    return {
+        extensions,
+        paramsWithoutExtensions,
+    };
+};
+
 const buildFacetFilters = function (facetFilters, needle) {
     return facetFilters.map((facetFilter) => {
         const refinements = Array.isArray(facetFilter) ? facetFilter : [facetFilter];
@@ -54,7 +62,7 @@ const _getSearchParams = function(args, params) {
 };
 
 
-const getDisjunctiveRequests = function (indexName, disjunctiveFacets, refinedFacets, paramsWithoutDisjunctiveFacets) {
+const getDisjunctiveRequests = function (indexName, disjunctiveFacets, refinedFacets, paramsWithoutDisjunctiveFacets, extensions) {
     const requests = [];
 
     requests.push({
@@ -63,6 +71,7 @@ const getDisjunctiveRequests = function (indexName, disjunctiveFacets, refinedFa
             ...paramsWithoutDisjunctiveFacets,
             facets: disjunctiveFacets,
         }, ''),
+        ...(extensions ? {extensions} : {}),
     });
 
     refinedFacets.forEach((facetName) => {
@@ -83,6 +92,7 @@ const getDisjunctiveRequests = function (indexName, disjunctiveFacets, refinedFa
         requests.push({
             indexName: indexName,
             params: _getSearchParams(Object.assign({}, paramsWithoutDisjunctiveFacets, forcedParams), ''),
+            ...(extensions ? {extensions} : {}),
         });
     });
 
@@ -90,7 +100,8 @@ const getDisjunctiveRequests = function (indexName, disjunctiveFacets, refinedFa
 };
 
 const disjunctiveSearch = async function (params) {
-    const {disjunctiveFacets, ...paramsWithoutDisjunctiveFacets} = params;
+    const {extensions, paramsWithoutExtensions} = splitExtensions(params);
+    const {disjunctiveFacets, ...paramsWithoutDisjunctiveFacets} = paramsWithoutExtensions;
 
     const facetFilters = paramsWithoutDisjunctiveFacets.facetFilters || [];
     const facetRefinements = {};
@@ -109,7 +120,7 @@ const disjunctiveSearch = async function (params) {
         return facetRefinements[facetName].length > 0;
     });
 
-    const requests = getDisjunctiveRequests(this.indexName, disjunctiveFacets, refinedFacets, paramsWithoutDisjunctiveFacets);
+    const requests = getDisjunctiveRequests(this.indexName, disjunctiveFacets, refinedFacets, paramsWithoutDisjunctiveFacets, extensions);
     const requestOptions = {};
     if (this.userId() !== undefined) requestOptions.headers = {'X-Algolia-User-ID': this.userId()};
 
@@ -144,8 +155,24 @@ const customSearch = function (params) {
     if (newParams.disjunctiveFacets && newParams.disjunctiveFacets.length > 0) return this.disjunctiveSearch(newParams);
     delete (newParams.disjunctiveFacets);
 
-    if (this.userId() !== undefined) newParams.headers = {'X-Algolia-User-ID': this.userId()};
-    return this.search(newParams.query || '', newParams);
+    const {extensions, paramsWithoutExtensions} = splitExtensions(newParams);
+
+    if (extensions) {
+        const requestOptions = {};
+        if (this.userId() !== undefined) requestOptions.headers = {'X-Algolia-User-ID': this.userId()};
+
+        return this.transporter.read({
+            method: 'POST',
+            path: encode('/1/indexes/%s/query', this.indexName),
+            data: {
+                params: serializeQueryParameters(paramsWithoutExtensions),
+                extensions,
+            },
+        }, requestOptions);
+    }
+
+    if (this.userId() !== undefined) paramsWithoutExtensions.headers = {'X-Algolia-User-ID': this.userId()};
+    return this.search(paramsWithoutExtensions.query || '', paramsWithoutExtensions);
 };
 
 const customBrowse = function (params) {
@@ -154,7 +181,8 @@ const customBrowse = function (params) {
     delete (newParams.disjunctiveFacets);
     delete (newParams.cursor);
 
-    const data = { params: serializeQueryParameters(newParams) };
+    const {paramsWithoutExtensions} = splitExtensions(newParams);
+    const data = { params: serializeQueryParameters(paramsWithoutExtensions) };
     if (cursor) data.cursor = cursor;
 
     const requestOptions = {};


### PR DESCRIPTION
_Note for reviewers:  this PR is AI-coded, I'm not familiar with this repo_

## Summary

This PR allows to setup "extensions" `workflowSelector.name` params in metaparams.
It also adds this params in the CURL url view.


<img width="324" height="246" alt="Screenshot 2026-06-02 at 12 33 00" src="https://github.com/user-attachments/assets/eb1ff2ca-88b0-4b1e-a17c-96ea645c1564" />
<img width="316" height="156" alt="Screenshot 2026-06-02 at 12 32 51" src="https://github.com/user-attachments/assets/10064625-90b9-4158-9377-ac51b75a68e8" />

<img width="1089" height="118" alt="Screenshot 2026-06-02 at 14 47 43" src="https://github.com/user-attachments/assets/a04e1a18-77b7-46c9-aa3c-b44122f63d7a" />

- Add `extensions` as a search-scoped metaparam with object editing support.
- Add local param autocomplete fallback so newly declared params are available even before the remote metaparams index is updated.
- Serialize `extensions` at the REST request boundary for search and disjunctive search, while keeping it as a normal Search Param in the UI.
- Import/export curl snippets with top-level `extensions` so generated REST calls match Algolia's query body shape.


## Validation

- `yarn run lint --no-fix` passes with 0 errors and the existing 37 warnings.
- Dev server compiled successfully at `http://localhost:8080/` with existing warnings only.